### PR TITLE
Fix: reset equation numbers to avoid `Label multiply defined` error.

### DIFF
--- a/src/MathJax/MathJax.tsx
+++ b/src/MathJax/MathJax.tsx
@@ -153,6 +153,7 @@ const MathJax: FC<MathJaxProps & ComponentPropsWithoutRef<"span">> = ({
                                             // renderMode "post"
                                             mathJax.startup.promise
                                                 .then(() => {
+                                                    mathJax.texReset() // reset equation numbers.
                                                     mathJax.typesetClear([ref.current])
                                                     return mathJax.typesetPromise([ref.current])
                                                 })

--- a/src/MathJax/MathJax.tsx
+++ b/src/MathJax/MathJax.tsx
@@ -9,8 +9,11 @@ export interface MathJaxProps extends MathJaxOverrideableProps {
     dynamic?: boolean
 }
 
-const typesettingFailed = (err: any) =>
+const typesettingFailed = (err: any): string =>
     `Typesetting failed: ${typeof err.message !== "undefined" ? err.message : err.toString()}`
+
+// validator for text input with renderMode = "pre"
+const validText = (inputText?: string): boolean => typeof inputText === "string" && inputText.length > 0
 
 const MathJax: FC<MathJaxProps & ComponentPropsWithoutRef<"span">> = ({
     inline = false,
@@ -46,7 +49,7 @@ const MathJax: FC<MathJaxProps & ComponentPropsWithoutRef<"span">> = ({
     const typesetting = useRef(false)
 
     // handler for initial loading
-    const checkInitLoad = () => {
+    const checkInitLoad = (): void => {
         if(!initLoad.current) {
             if(usedHideUntilTypeset === "first" && ref.current !== null) {
                 ref.current.style.visibility = "visible"
@@ -57,7 +60,7 @@ const MathJax: FC<MathJaxProps & ComponentPropsWithoutRef<"span">> = ({
     }
 
     // callback for when typesetting is done
-    const onTypesetDone = () => {
+    const onTypesetDone = (): void => {
         if(usedHideUntilTypeset === "every" && usedDynamic && usedRenderMode === "post" && ref.current !== null) {
             ref.current.style.visibility = rest.style?.visibility ?? "visible"
         }
@@ -65,9 +68,6 @@ const MathJax: FC<MathJaxProps & ComponentPropsWithoutRef<"span">> = ({
         if(onTypeset) onTypeset()
         typesetting.current = false
     }
-
-    // validator for text input with renderMode = "pre"
-    const validText = (inputText?: string) => typeof inputText === "string" && inputText.length > 0
 
     // guard which resets the visibility to hidden when hiding the content between every typesetting
     if(
@@ -116,7 +116,7 @@ const MathJax: FC<MathJaxProps & ComponentPropsWithoutRef<"span">> = ({
                                 mjPromise.promise
                                     .then((mathJax) => {
                                         if(usedRenderMode === "pre") {
-                                            const updateFn = (output: HTMLElement) => {
+                                            const updateFn = (output: HTMLElement): void => {
                                                 lastChildren.current = text!
                                                 mathJax.startup.document.clear()
                                                 mathJax.startup.document.updateDocument()


### PR DESCRIPTION
Hi @fast-reflexes , thank you for creating such a awesome project, I'm really appreciate it! But I encountered a typesetting bug when using this package, so I create this pr and hope this pr can fix it.

## Scenario

In a single-page application, when we switch routes and trigger the MathJax to re-render the page, if a formula in the page uses the `\label` instruction, it will cause the `Label multiple 'xxx' defined` error.

## Changes

* improve: add strong types.
* fix: reset equation numbers before reprocess to avoid `Label multiple defined` error.
  - Before
    ![image](https://user-images.githubusercontent.com/42513619/198005286-76469cd5-a343-4ab9-bce1-a006841015de.png)

  - After
    ![image](https://user-images.githubusercontent.com/42513619/198005355-1dbec688-fe37-4974-a752-2404a4c0e10d.png)
