### PR TITLE
add `'use client'` directives

### DIFF
--- a/src/MathJax/MathJax.tsx
+++ b/src/MathJax/MathJax.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import React, { ComponentPropsWithoutRef, FC, useContext, useEffect, useLayoutEffect, useRef } from "react"
 import { MathJaxBaseContext, MathJaxOverrideableProps } from "../MathJaxContext"
 

--- a/src/MathJaxContext/MathJaxContext.tsx
+++ b/src/MathJaxContext/MathJaxContext.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import React, { createContext, FC, ReactNode, useContext, useRef } from "react"
 import type { MathJax2Config, MathJax2Object } from "../MathJax2"
 import type { MathJax3Config, MathJax3Object, OptionList } from "../MathJax3"


### PR DESCRIPTION
this will avoid specifying `'use client'` directives manually https://github.com/shuding/nextra/blob/main/packages/nextra/src/client/components/mathjax.ts in SSR frameworks